### PR TITLE
Add support for relay-server-port

### DIFF
--- a/templates/setup_tailscale.sh.tmpl
+++ b/templates/setup_tailscale.sh.tmpl
@@ -58,6 +58,10 @@ do
     if [ -n "${OPERATOR}" ]; then
       tailscale set --operator="${OPERATOR}"
     fi
+
+    if [ -n "${RELAY_SERVER_PORT}" ]; then
+      tailscale set --relay-server-port="${RELAY_SERVER_PORT}"
+    fi
     
     echo "Tailscale installation and configuration succeeded"
     exit 0


### PR DESCRIPTION
Signed-off-by: Zach Buchheit <zachb@tailscale.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `RELAY_SERVER_PORT` configuration in `setup_tailscale.sh.tmpl`.
> 
>   - **Behavior**:
>     - Adds support for `RELAY_SERVER_PORT` in `setup_tailscale.sh.tmpl`.
>     - If `RELAY_SERVER_PORT` is set, configures Tailscale with `--relay-server-port` option.
>   - **Misc**:
>     - No changes to existing logic or other configuration options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lbrlabs%2Fterraform-cloudinit-tailscale&utm_source=github&utm_medium=referral)<sup> for 1ad79595daca454f3838a90cd1890b1dbcf1bca9. You can [customize](https://app.ellipsis.dev/lbrlabs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->