### PR TITLE
Add a check to see if ethtool is installed

### DIFF
--- a/files/udp_offloads.sh
+++ b/files/udp_offloads.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Ensure ethtool is installed
+if ! command -v ethtool >/dev/null 2>&1; then
+    echo "ethtool not found. Skipping network optimizations."
+    exit 0
+fi
+
 # Get the current kernel version
 current_version=$(uname -r | cut -d'-' -f1 | cut -d'.' -f1,2)
 


### PR DESCRIPTION
Adds a check for ethtool before performing UDP throughput improvements. If ethtool is not present, skip the optimization.

Fixes: https://github.com/tailscale/terraform-cloudinit-tailscale/issues/10